### PR TITLE
fix: cors 이슈 해결

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/WebMvcConfig.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/WebMvcConfig.kt
@@ -1,0 +1,14 @@
+package com.example.cafe
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:5173")
+            .allowedMethods("OPTIONS", "GET", "POST", "PUT", "DELETE")
+    }
+}


### PR DESCRIPTION
프론트엔드와 백엔드 연동시 발생하는 주요한 이슈인 cors 에러를 해결했습니다.

cors란 : https://hannut91.github.io/blogs/infra/cors

간단히 말해서 리액트에서 스프링으로 url 요청을 날리면 서로 도메인이 다르기 때문에 cors 정책에 의하여 자료를 공유할 수 없게 됩니다. 하지만 서버 측(스프링)과 클라이언트 측(리액트)에서 각각 설정을 통해서 해결할 수 있습니다.