### PR TITLE
comment 관련 기능 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/cafe" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" project-jdk-name="17 (2)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/cafe" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="17 (2)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleEntity.kt
@@ -1,6 +1,7 @@
 package com.example.cafe.article.repository
 
 import com.example.cafe.board.repository.BoardEntity
+import com.example.cafe.comment.repository.CommentEntity
 import com.example.cafe.user.repository.UserEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -23,5 +24,7 @@ class ArticleEntity (
         @JoinColumn(name = "board_id")
         val board : BoardEntity,
         val allowComments : Boolean,
-        val isNotification : Boolean
+        val isNotification : Boolean,
+        @OneToMany(mappedBy = "article", cascade = [CascadeType.REMOVE])
+        val comments: MutableList<CommentEntity> = mutableListOf(),
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
@@ -1,18 +1,69 @@
 package com.example.cafe.comment.controller
 
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import com.example.cafe.comment.service.Comment
 import com.example.cafe.comment.service.CommentService
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDateTime
 
 @RestController
 class CommentController(
     private val commentService: CommentService,
 ) {
-    //TODO
+    @PostMapping("/api/v1/articles/{articleId}/comments")
+    fun postComment(
+        @RequestParam userId: String,
+        @RequestParam content: String,
+        @PathVariable articleId: Long,
+    ) : PostCommentResponse {
+        val comment = commentService.createComment(userId, articleId, content)
+        return PostCommentResponse(
+            commentId = comment.id,
+            content = comment.content,
+            lastModified = comment.lastModified,
+            nickname = comment.nickname,
+        )
+    }
+
+    @GetMapping("/api/v1/articles/{articleId}/comments")
+    fun getComment(
+        @PathVariable articleId: Long,
+    ) : GetCommentResponse {
+        val comments = commentService.getComments(articleId)
+        return GetCommentResponse(comments = comments)
+    }
+
+    @PutMapping("/api/v1/articles/{articleId}/comments/{commentId}")
+    fun updateComment(
+        @RequestParam userId: String,
+        @RequestParam content: String,
+        @PathVariable articleId: Long,
+        @PathVariable commentId: Long,
+    ) : UpdateCommentResponse {
+        val comment = commentService.updateComment(commentId, userId, content)
+        return UpdateCommentResponse(comment = comment)
+    }
+
+    @DeleteMapping("/api/v1/articles/{articleId}/comments/{commentId}")
+    fun deleteComment(
+        @RequestParam userId: String,
+        @PathVariable articleId: Long,
+        @PathVariable commentId: Long,
+    ) {
+        commentService.deleteComment(commentId, userId)
+    }
 }
 
-data class CommentRequest(
-    val content: String
-    //TODO
+data class PostCommentResponse(
+    val commentId: Long,
+    val content: String,
+    val lastModified: LocalDateTime,
+    val nickname: String,
+)
+
+data class GetCommentResponse(
+    val comments: List<Comment>,
+)
+
+data class UpdateCommentResponse(
+    val comment:Comment,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
@@ -1,7 +1,7 @@
 package com.example.cafe.comment.controller
 
-import com.example.cafe.comment.service.Comment
-import com.example.cafe.comment.service.CommentService
+import com.example.cafe.comment.service.*
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
 
@@ -51,6 +51,63 @@ class CommentController(
     ) {
         commentService.deleteComment(commentId, userId)
     }
+
+    @PostMapping("/api/v1/articles/{articleId}/comments/{commentId}/recomments")
+    fun postRecomment(
+        @RequestParam userId: String,
+        @RequestParam content: String,
+        @PathVariable articleId: Long,
+        @PathVariable commentId: Long,
+        ) : PostRecommentResponse {
+        val recomment = commentService.createRecomment(userId, commentId, content)
+        return PostRecommentResponse(
+            recommentId = recomment.id,
+            content = recomment.content,
+            lastModified = recomment.lastModified,
+            nickname = recomment.nickname,
+        )
+    }
+
+    @GetMapping("/api/v1/articles/{articleId}/comments/{commentId}/recomments")
+    fun getRecomment(
+        @PathVariable articleId: Long,
+        @PathVariable commentId: Long,
+        ) : GetRecommentResponse {
+        val recomments = commentService.getRecomments(commentId)
+        return GetRecommentResponse(recomments = recomments)
+    }
+
+    @PutMapping("/api/v1/articles/{articleId}/comments/{commentId}/recomments/{recommentId}")
+    fun updateRecomment(
+        @RequestParam userId: String,
+        @RequestParam content: String,
+        @PathVariable articleId: Long,
+        @PathVariable commentId: Long,
+        @PathVariable recommentId: Long,
+        ) : UpdateRecommentResponse {
+        val recomment = commentService.updateRecomment(recommentId, userId, content)
+        return UpdateRecommentResponse(recomment = recomment)
+    }
+
+    @DeleteMapping("/api/v1/articles/{articleId}/comments/{commentId}/recomments/{recommentId}")
+    fun deleteRecomment(
+        @RequestParam userId: String,
+        @PathVariable articleId: Long,
+        @PathVariable commentId: Long,
+        @PathVariable recommentId: Long,
+        ) {
+        commentService.deleteRecomment(recommentId, userId)
+    }
+
+    @ExceptionHandler
+    fun handleException(e: CommentException): ResponseEntity<Unit> {
+        val status = when (e) {
+            is CommentNotFoundException, is RecommentNotFoundException, is CommentUserNotFoundException, is CommentArticleNotFoundException -> 404
+            is InvalidCommentUserException -> 403
+        }
+
+        return ResponseEntity.status(status).build()
+    }
 }
 
 data class PostCommentResponse(
@@ -65,5 +122,20 @@ data class GetCommentResponse(
 )
 
 data class UpdateCommentResponse(
-    val comment:Comment,
+    val comment: Comment,
+)
+
+data class PostRecommentResponse(
+    val recommentId: Long,
+    val content: String,
+    val lastModified: LocalDateTime,
+    val nickname: String,
+)
+
+data class GetRecommentResponse(
+    val recomments: List<Recomment>,
+)
+
+data class UpdateRecommentResponse(
+    val recomment: Recomment,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/repository/CommentEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/repository/CommentEntity.kt
@@ -10,7 +10,7 @@ class CommentEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    val content: String,
+    var content: String,
     var lastModified: LocalDateTime,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -18,6 +18,6 @@ class CommentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id")
     val article: ArticleEntity,
-    @OneToMany(mappedBy = "comment")
-    val recomments: List<RecommentEntity> = emptyList(),
+    @OneToMany(mappedBy = "comment", cascade = [CascadeType.REMOVE])
+    val recomments: MutableList<RecommentEntity> = mutableListOf(),
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/repository/RecommentEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/repository/RecommentEntity.kt
@@ -15,7 +15,7 @@ class RecommentEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    val content: String,
+    var content: String,
     var lastModified: LocalDateTime,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/Comment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/Comment.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 data class Comment(
     val id: Long,
     val content: String,
-    var updatedAt: LocalDateTime,
-    val user: String,
+    var lastModified: LocalDateTime,
+    val nickname: String,
+    val recomments: List<Recomment> = emptyList(),
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/Comment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/Comment.kt
@@ -5,6 +5,6 @@ import java.time.LocalDateTime
 data class Comment(
     val id: Long,
     val content: String,
-    var createdAt: LocalDateTime,
+    var updatedAt: LocalDateTime,
     val user: String,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentException.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentException.kt
@@ -7,3 +7,7 @@ class CommentNotFoundException : CommentException()
 class RecommentNotFoundException : CommentException()
 
 class InvalidCommentUserException : CommentException() // 댓글, 대댓글 작성자가 아닌데 수정 또는 삭제 요청
+
+class CommentUserNotFoundException : CommentException()
+
+class CommentArticleNotFoundException : CommentException()

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
@@ -7,10 +7,10 @@ interface CommentService {
     fun getComments(articleId: Long): List<Comment>
     fun getRecomment(id: Long): Recomment
     fun getRecomments(commentId: Long): List<Recomment>
-    fun createComment(userId: Long, articleId: Long, at: LocalDateTime = LocalDateTime.now())
-    fun createRecomment(userId: Long, commentId: Long, at: LocalDateTime = LocalDateTime.now())
-    fun modifyComment(id: Long, userId: Long, content: String, at: LocalDateTime = LocalDateTime.now())
-    fun modifyRecomment(id: Long, userId: Long, content: String, at: LocalDateTime = LocalDateTime.now())
-    fun deleteComment(id: Long, userId: Long)
-    fun deleteRecomment(id: Long, userId: Long)
+    fun createComment(userId: String, articleId: Long, content: String, at: LocalDateTime = LocalDateTime.now()): Comment
+    fun createRecomment(userId: String, commentId: Long, content: String, at: LocalDateTime = LocalDateTime.now()): Recomment
+    fun updateComment(id: Long, userId: String, content: String, at: LocalDateTime = LocalDateTime.now()) : Comment
+    fun updateRecomment(id: Long, userId: String, content: String, at: LocalDateTime = LocalDateTime.now()) : Recomment
+    fun deleteComment(id: Long, userId: String)
+    fun deleteRecomment(id: Long, userId: String)
 }

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
@@ -3,9 +3,7 @@ package com.example.cafe.comment.service
 import java.time.LocalDateTime
 
 interface CommentService {
-    fun getComment(id: Long): Comment
     fun getComments(articleId: Long): List<Comment>
-    fun getRecomment(id: Long): Recomment
     fun getRecomments(commentId: Long): List<Recomment>
     fun createComment(userId: String, articleId: Long, content: String, at: LocalDateTime = LocalDateTime.now()): Comment
     fun createRecomment(userId: String, commentId: Long, content: String, at: LocalDateTime = LocalDateTime.now()): Recomment

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
@@ -9,8 +9,8 @@ interface CommentService {
     fun getRecomments(commentId: Long): List<Recomment>
     fun createComment(userId: Long, articleId: Long, at: LocalDateTime = LocalDateTime.now())
     fun createRecomment(userId: Long, commentId: Long, at: LocalDateTime = LocalDateTime.now())
-    fun modifyComment(id: Long, userId: Long, content: String)
-    fun modifyRecomment(id: Long, userId: Long, content: String)
+    fun modifyComment(id: Long, userId: Long, content: String, at: LocalDateTime = LocalDateTime.now())
+    fun modifyRecomment(id: Long, userId: Long, content: String, at: LocalDateTime = LocalDateTime.now())
     fun deleteComment(id: Long, userId: Long)
     fun deleteRecomment(id: Long, userId: Long)
 }

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
@@ -8,6 +8,7 @@ import com.example.cafe.comment.repository.RecommentRepository
 import com.example.cafe.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
@@ -89,6 +90,7 @@ class CommentServiceImpl (
         )
     }
 
+    @Transactional
     override fun updateComment(id: Long, userId: String, content: String, at: LocalDateTime) : Comment {
         val comment = commentRepository.findByIdOrNull(id) ?: throw CommentNotFoundException()
         if (comment.user.userId != userId) {
@@ -112,6 +114,7 @@ class CommentServiceImpl (
         )
     }
 
+    @Transactional
     override fun updateRecomment(id: Long, userId: String, content: String, at: LocalDateTime) : Recomment {
         val recomment = recommentRepository.findByIdOrNull(id) ?: throw RecommentNotFoundException()
         if (recomment.user.userId != userId) {

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
@@ -3,6 +3,8 @@ package com.example.cafe.comment.service
 import com.example.cafe.article.repository.ArticleRepository
 import com.example.cafe.comment.repository.CommentEntity
 import com.example.cafe.comment.repository.CommentRepository
+import com.example.cafe.comment.repository.RecommentEntity
+import com.example.cafe.comment.repository.RecommentRepository
 import com.example.cafe.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -11,13 +13,10 @@ import java.time.LocalDateTime
 @Service
 class CommentServiceImpl (
     private val commentRepository: CommentRepository,
+    private val recommentRepository: RecommentRepository,
     private val userRepository: UserRepository,
     private val articleRepository: ArticleRepository,
 ) : CommentService {
-    override fun getComment(id: Long): Comment {
-        TODO()
-    }
-
     override fun getComments(articleId: Long): List<Comment> {
         val article = articleRepository.findByIdOrNull(articleId) ?: throw CommentArticleNotFoundException()
         val comments = article.comments.map{ commentEntity ->
@@ -39,12 +38,17 @@ class CommentServiceImpl (
         return comments
     }
 
-    override fun getRecomment(id: Long): Recomment {
-        TODO()
-    }
-
     override fun getRecomments(commentId: Long): List<Recomment> {
-        TODO()
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw CommentNotFoundException()
+        val recomments = comment.recomments.map{ recommentEntity ->
+            Recomment(
+                id = recommentEntity.id,
+                content = recommentEntity.content,
+                lastModified = recommentEntity.lastModified,
+                nickname = recommentEntity.user.nickname,
+            )
+        }
+        return recomments
     }
 
     override fun createComment(userId: String, articleId: Long, content: String, at: LocalDateTime): Comment {
@@ -67,7 +71,22 @@ class CommentServiceImpl (
     }
 
     override fun createRecomment(userId: String, commentId: Long, content: String, at: LocalDateTime) : Recomment {
-        TODO()
+        val user = userRepository.findByUserId(userId) ?: throw CommentUserNotFoundException()
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw CommentNotFoundException()
+        val recomment = recommentRepository.save(
+            RecommentEntity(
+                content = content,
+                lastModified = at,
+                user = user,
+                comment = comment,
+            )
+        )
+        return Recomment(
+            id = recomment.id,
+            content = recomment.content,
+            lastModified = recomment.lastModified,
+            nickname = recomment.user.nickname,
+        )
     }
 
     override fun updateComment(id: Long, userId: String, content: String, at: LocalDateTime) : Comment {
@@ -94,15 +113,33 @@ class CommentServiceImpl (
     }
 
     override fun updateRecomment(id: Long, userId: String, content: String, at: LocalDateTime) : Recomment {
-        TODO()
+        val recomment = recommentRepository.findByIdOrNull(id) ?: throw RecommentNotFoundException()
+        if (recomment.user.userId != userId) {
+            throw InvalidCommentUserException()
+        }
+        recomment.content = content
+        recomment.lastModified = at
+        return Recomment(
+            id = recomment.id,
+            content = recomment.content,
+            lastModified = recomment.lastModified,
+            nickname = recomment.user.nickname,
+        )
     }
 
     override fun deleteComment(id: Long, userId: String) {
         val comment = commentRepository.findByIdOrNull(id) ?: throw CommentNotFoundException()
+        if (comment.user.userId != userId) {
+            throw InvalidCommentUserException()
+        }
         commentRepository.delete(comment)
     }
 
     override fun deleteRecomment(id: Long, userId: String) {
-        TODO()
+        val recomment = recommentRepository.findByIdOrNull(id) ?: throw RecommentNotFoundException()
+        if (recomment.user.userId != userId) {
+            throw InvalidCommentUserException()
+        }
+        recommentRepository.delete(recomment)
     }
 }

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
@@ -33,11 +33,11 @@ class CommentServiceImpl (
         TODO()
     }
 
-    override fun modifyComment(id: Long, userId: Long, content: String) {
+    override fun modifyComment(id: Long, userId: Long, content: String, at: LocalDateTime) {
         TODO()
     }
 
-    override fun modifyRecomment(id: Long, userId: Long, content: String) {
+    override fun modifyRecomment(id: Long, userId: Long, content: String, at: LocalDateTime) {
         TODO()
     }
 

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/Recomment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/Recomment.kt
@@ -5,6 +5,6 @@ import java.time.LocalDateTime
 data class Recomment(
     val id: Long,
     val content: String,
-    var createdAt: LocalDateTime,
+    var updatedAt: LocalDateTime,
     val user: String,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/Recomment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/Recomment.kt
@@ -5,6 +5,6 @@ import java.time.LocalDateTime
 data class Recomment(
     val id: Long,
     val content: String,
-    var updatedAt: LocalDateTime,
-    val user: String,
+    var lastModified: LocalDateTime,
+    val nickname: String,
 )

--- a/cafe/src/main/resources/application.yaml
+++ b/cafe/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: prob
+    active: prod
   config:
     import: classpath:application-db.yaml
 

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-정INSERT into users (id, user_id, password, username, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', '홍길동', 'hong@naver.com', '2000-05-03', '01023453444'),
+INSERT into users (id, user_id, password, username, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', '홍길동', 'hong@naver.com', '2000-05-03', '01023453444'),
 (2, 'doo', 'doo123', '황두현', '황두현', 'doo@naver.com', '1997-04-26', '01023446673');
 
 INSERT into board_groups (id, name) VALUES (1, '백엔드'),


### PR DESCRIPTION
회의한 내용을 바탕으로 Entity와 data class 일부를 수정했습니다.
Comment와 Recomment 조회, 작성, 수정, 삭제를 구현하면서 Entity 내용을 약간 수정했습니다.
ArticleEntity에 OneToMany 관계로 comments를 추가했습니다.
기존에 CommentEntity와 RecommentEntity에서 MutableList를 사용해야하는데 List를 사용하여 이를 MutableList로 수정했습니다.
댓글, 대댓글 작성, 조회, 수정, 삭제를 구현했으며 Postman으로 확인한 결과 문제 없이 잘 돌아갔습니다.