### PR TITLE
board 기본구현

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleEntity.kt
@@ -1,6 +1,7 @@
 package com.example.cafe.article.repository
 
 import com.example.cafe.board.repository.BoardEntity
+import com.example.cafe.comment.repository.CommentEntity
 import com.example.cafe.user.repository.UserEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -23,5 +24,7 @@ class ArticleEntity (
         @JoinColumn(name = "board_id")
         val board : BoardEntity,
         val allowComments : Boolean,
-        val isNotification : Boolean
+        val isNotification : Boolean,
+        @OneToMany(mappedBy = "article", cascade = [CascadeType.REMOVE])
+        val comments: MutableList<CommentEntity> = mutableListOf(),
 )

--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -1,8 +1,12 @@
 package com.example.cafe.article.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface ArticleRepository : JpaRepository<ArticleEntity, Long>{
     //fun findByName(name: String): ArticleEntity?
     //fun findByNameIn(names: List<String>): List<ArticleEntity>
+
+    @Query("SELECT a FROM articles a JOIN FETCH a.user JOIN FETCH a.comments WHERE a.board.id = :boardId")
+    fun findByBoardId(boardId: Long): List<ArticleEntity>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/article/service/ArticleBrief.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/service/ArticleBrief.kt
@@ -1,0 +1,17 @@
+package com.example.cafe.article.service
+
+import com.example.cafe.board.service.Board
+import com.example.cafe.user.service.User
+import java.time.LocalDateTime
+
+data class ArticleBrief (
+    val articleId: Long,
+    val title: String,
+    val author: User,
+    val board: Board,
+    val likeCount: Long,
+    val viewCount: Long,
+    val commentCount: Int,
+    val createdAt: LocalDateTime,
+    val isNotification: Boolean,
+)

--- a/cafe/src/main/kotlin/com/example/cafe/article/service/ArticleBrief.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/service/ArticleBrief.kt
@@ -7,11 +7,11 @@ import java.time.LocalDateTime
 data class ArticleBrief (
     val articleId: Long,
     val title: String,
+    val createdAt: LocalDateTime,
+    val viewCount: Long,
+    val likeCount: Long,
+    val commentCount: Int,
     val author: User,
     val board: Board,
-    val likeCount: Long,
-    val viewCount: Long,
-    val commentCount: Int,
-    val createdAt: LocalDateTime,
     val isNotification: Boolean,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -1,11 +1,70 @@
 package com.example.cafe.board.controller
 
+import com.example.cafe.article.controller.ArticlePostRequest
+import com.example.cafe.article.service.ArticleBrief
+import com.example.cafe.board.service.Board
+import com.example.cafe.board.service.BoardGroup
+import com.example.cafe.board.service.BoardLikeService
 import com.example.cafe.board.service.BoardService
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class BoardController(
     private val boardService: BoardService,
+    private val boardLikeService: BoardLikeService,
 ) {
+    @GetMapping("/api/v1/boards-in-group")
+    fun getBoardGroup(
+    ):BoardGroupResponse {
+        return BoardGroupResponse(boardService.getGroup())
+    }
+
+    @GetMapping("/api/v1/boards")
+    fun getBoard(
+    ):BoardResponse {
+        return BoardResponse(boardService.get())
+    }
+
+    @PostMapping("/api/v1/boards/{boardId}/likes")
+    fun likeBoard(
+        @PathVariable boardId: Long,
+        @RequestParam userId: String
+    ) {
+        boardLikeService.create(userId, boardId)
+    }
+
+    @DeleteMapping("/api/v1/boards/{boardId}/likes")
+    fun undoLikeBoard(
+        @PathVariable boardId: Long,
+        @RequestParam userId: String
+    ) {
+        boardLikeService.delete(userId, boardId)
+    }
+
+    @GetMapping("/api/v1/boards/likes")
+    fun getLikeBoard(
+        @RequestParam userId: String
+    ):BoardResponse {
+        return BoardResponse(boardLikeService.get(userId))
+    }
+
+    @GetMapping("/api/v1/boards/{boardId}/articles")
+    fun getBoardArticle(
+        @PathVariable boardId: Long,
+    ):ArticleBriefResponse {
+        return ArticleBriefResponse(boardService.getArticles(boardId))
+    }
 
 }
+
+data class BoardGroupResponse(
+    val boardGroups: List<BoardGroup>,
+)
+
+data class BoardResponse(
+    val boards: List<Board>,
+)
+
+data class ArticleBriefResponse(
+    val articleBrief: List<ArticleBrief>
+)

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -1,11 +1,8 @@
 package com.example.cafe.board.controller
 
-import com.example.cafe.article.controller.ArticlePostRequest
 import com.example.cafe.article.service.ArticleBrief
-import com.example.cafe.board.service.Board
-import com.example.cafe.board.service.BoardGroup
-import com.example.cafe.board.service.BoardLikeService
-import com.example.cafe.board.service.BoardService
+import com.example.cafe.board.service.*
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -53,6 +50,16 @@ class BoardController(
         @PathVariable boardId: Long,
     ):ArticleBriefResponse {
         return ArticleBriefResponse(boardService.getArticles(boardId))
+    }
+
+    @ExceptionHandler
+    fun handleException(e: BoardException): ResponseEntity<Unit> {
+        val status = when (e) {
+            is BoardUserNotFoundException, is BoardNotFoundException, is BoardNeverLikedException -> 404
+            is BoardAlreadyLikedException -> 409
+        }
+
+        return ResponseEntity.status(status).build()
     }
 
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardEntity.kt
@@ -14,6 +14,8 @@ class BoardEntity(
     val group: BoardGroupEntity,
     val viewCnt: Long,
     val likeCnt: Long,
-    @OneToMany(mappedBy = "board")
-    val articles: List<ArticleEntity>,
+    @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL])
+    val articles: MutableList<ArticleEntity>,
+    @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL])
+    val boardLikes: MutableList<BoardLikeEntity>,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardGrouprepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardGrouprepository.kt
@@ -1,0 +1,9 @@
+package com.example.cafe.board.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface BoardGroupRepository : JpaRepository<BoardGroupEntity, Long> {
+    @Query("SELECT bg FROM board_groups bg JOIN FETCH bg.boards")
+    fun find(): List<BoardGroupEntity>
+}

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeEntity.kt
@@ -7,6 +7,8 @@ class BoardLikeEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    val boardId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    val board: BoardEntity,
     val userId: Long,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
@@ -3,5 +3,5 @@ package com.example.cafe.board.repository
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface BoardLikeRepository : JpaRepository<BoardLikeEntity, Long> {
-    fun findByUserIdAndBoardId(userId: Long, boardId: Long): BoardLikeEntity
+    fun findByUserIdAndBoardId(userId: Long, boardId: Long): BoardLikeEntity?
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
@@ -1,0 +1,7 @@
+package com.example.cafe.board.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BoardLikeRepository : JpaRepository<BoardLikeEntity, Long> {
+    fun findByUserIdAndBoardId(userId: Long, boardId: Long): BoardLikeEntity
+}

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardRepository.kt
@@ -1,7 +1,12 @@
 package com.example.cafe.board.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface BoardRepository : JpaRepository<BoardEntity, Long> {
+    @Query("SELECT b FROM boards b")
+    fun find(): List<BoardEntity>
 
+    @Query("SELECT b FROM boards b JOIN b.boardLikes bl WHERE bl.userId = :userId")
+    fun findByUserId(userId: Long): List<BoardEntity>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/Board.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/Board.kt
@@ -1,0 +1,6 @@
+package com.example.cafe.board.service
+
+data class Board (
+    val id: Long,
+    val name: String,
+)

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardException.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardException.kt
@@ -2,4 +2,7 @@ package com.example.cafe.board.service
 
 sealed class BoardException : RuntimeException()
 
-class UserNotFoundException : BoardException()
+class BoardUserNotFoundException : BoardException()
+class BoardNotFoundException : BoardException()
+class BoardAlreadyLikedException : BoardException()
+class BoardNeverLikedException : BoardException()

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardException.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardException.kt
@@ -1,0 +1,5 @@
+package com.example.cafe.board.service
+
+sealed class BoardException : RuntimeException()
+
+class UserNotFoundException : BoardException()

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardGroup.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardGroup.kt
@@ -1,0 +1,7 @@
+package com.example.cafe.board.service
+
+data class BoardGroup (
+    val id: Long,
+    val name: String,
+    val boards: List<Board>
+)

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeService.kt
@@ -1,6 +1,8 @@
 package com.example.cafe.board.service
 
 interface BoardLikeService {
+    fun exist(userId: Long, boardId: Long): Boolean
+
     fun get(userId: String): List<Board>
 
     fun create(userId: String, boardId: Long)

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeService.kt
@@ -1,0 +1,9 @@
+package com.example.cafe.board.service
+
+interface BoardLikeService {
+    fun get(userId: String): List<Board>
+
+    fun create(userId: String, boardId: Long)
+
+    fun delete(userId: String, boardId: Long)
+}

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
@@ -41,7 +41,7 @@ class BoardLikeServiceImpl (
         boardLikeRepository.save(
             BoardLikeEntity(
                 userId = user.id,
-                board = boardRepository.findById(boardId).get() //null?
+                board = boardRepository.findById(boardId).get()
             )
         )
     }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
@@ -1,0 +1,45 @@
+package com.example.cafe.board.service
+
+import com.example.cafe.board.repository.BoardLikeEntity
+import com.example.cafe.board.repository.BoardLikeRepository
+import com.example.cafe.board.repository.BoardRepository
+import com.example.cafe.user.repository.UserRepository
+import org.springframework.stereotype.Service
+
+@Service
+class BoardLikeServiceImpl (
+    private val boardLikeRepository: BoardLikeRepository,
+    private val boardRepository: BoardRepository,
+    private val userRepository: UserRepository
+) : BoardLikeService {
+    override fun get(userId: String): List<Board> {
+        val user = userRepository.findByUserId(userId) ?: throw UserNotFoundException()
+        val boardLikeList = boardRepository.findByUserId(user.id)
+
+        return boardLikeList.map {
+            Board(
+                id = it.id,
+                name = it.name
+            )
+        }
+    }
+
+    override fun create(userId: String, boardId: Long) {
+        val user = userRepository.findByUserId(userId) ?: throw UserNotFoundException()
+
+        boardLikeRepository.save(
+            BoardLikeEntity(
+                userId = user.id,
+                board = boardRepository.findById(boardId).get() //null?
+            )
+        )
+    }
+
+    override fun delete(userId: String, boardId: Long) {
+        val user = userRepository.findByUserId(userId) ?: throw UserNotFoundException()
+        val boardLike = boardLikeRepository.findByUserIdAndBoardId(user.id, boardId)
+
+        boardLikeRepository.delete(boardLike)
+    }
+
+}

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardService.kt
@@ -1,6 +1,5 @@
 package com.example.cafe.board.service
 
-import com.example.cafe.article.service.Article
 import com.example.cafe.article.service.ArticleBrief
 
 interface BoardService {

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardService.kt
@@ -1,4 +1,12 @@
 package com.example.cafe.board.service
 
+import com.example.cafe.article.service.Article
+import com.example.cafe.article.service.ArticleBrief
+
 interface BoardService {
+    fun get(): List<Board>
+
+    fun getGroup(): List<BoardGroup>
+
+    fun getArticles(boardId: Long): List<ArticleBrief>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardServiceImpl.kt
@@ -1,11 +1,60 @@
 package com.example.cafe.board.service
 
+import com.example.cafe.article.repository.ArticleRepository
+import com.example.cafe.article.service.Article
+import com.example.cafe.article.service.ArticleBrief
+import com.example.cafe.board.repository.BoardGroupRepository
 import com.example.cafe.board.repository.BoardRepository
+import com.example.cafe.user.service.User
 import org.springframework.stereotype.Service
 
 @Service
 class BoardServiceImpl (
     private val boardRepository: BoardRepository,
+    private val boardGroupRepository: BoardGroupRepository,
+    private val articleRepository: ArticleRepository,
 ) : BoardService {
+    override fun get(): List<Board> {
+        val boardList = boardRepository.find()
+
+        return boardList.map {
+            Board(
+                id = it.id,
+                name = it.name
+            )
+        }
+    }
+
+    override fun getGroup(): List<BoardGroup> {
+        val boardGroupList = boardGroupRepository.find()
+
+        return boardGroupList.map {boardGroup->
+            BoardGroup(
+                id = boardGroup.id,
+                name = boardGroup.name,
+                boards = boardGroup.boards.map {board->
+                    Board(id = board.id, name = board.name)
+                }
+            )
+        }
+    }
+
+    override fun getArticles(boardId: Long): List<ArticleBrief> {
+        val articleList = articleRepository.findByBoardId(boardId)
+
+        return articleList.map {article->
+            ArticleBrief(
+                articleId = article.id,
+                title = article.title,
+                author = User(userId = article.user.userId, username = article.user.username),
+                board = Board(id = article.board.id, name = article.board.name),
+                likeCount = article.likeCnt,
+                viewCount = article.viewCnt,
+                commentCount = article.comments.size,
+                createdAt = article.createdAt,
+                isNotification = article.isNotification,
+            )
+        }
+    }
 
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardServiceImpl.kt
@@ -1,7 +1,6 @@
 package com.example.cafe.board.service
 
 import com.example.cafe.article.repository.ArticleRepository
-import com.example.cafe.article.service.Article
 import com.example.cafe.article.service.ArticleBrief
 import com.example.cafe.board.repository.BoardGroupRepository
 import com.example.cafe.board.repository.BoardRepository
@@ -40,18 +39,19 @@ class BoardServiceImpl (
     }
 
     override fun getArticles(boardId: Long): List<ArticleBrief> {
+        val board = boardRepository.findById(boardId).orElseThrow{ BoardNotFoundException() }
         val articleList = articleRepository.findByBoardId(boardId)
 
         return articleList.map {article->
             ArticleBrief(
                 articleId = article.id,
                 title = article.title,
-                author = User(userId = article.user.userId, username = article.user.username),
-                board = Board(id = article.board.id, name = article.board.name),
-                likeCount = article.likeCnt,
-                viewCount = article.viewCnt,
-                commentCount = article.comments.size,
                 createdAt = article.createdAt,
+                viewCount = article.viewCnt,
+                likeCount = article.likeCnt,
+                commentCount = article.comments.size,
+                author = User(userId = article.user.userId, username = article.user.username),
+                board = Board(id = board.id, name = board.name),
                 isNotification = article.isNotification,
             )
         }

--- a/cafe/src/main/resources/application.yaml
+++ b/cafe/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: local
+    active: prob
   config:
     import: classpath:application-db.yaml
 

--- a/cafe/src/main/resources/application.yaml
+++ b/cafe/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: prob
+    active: local
   config:
     import: classpath:application-db.yaml
 

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-정INSERT into users (id, user_id, password, username, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', '홍길동', 'hong@naver.com', '2000-05-03', '01023453444'),
+INSERT into users (id, user_id, password, username, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', '홍길동', 'hong@naver.com', '2000-05-03', '01023453444'),
 (2, 'doo', 'doo123', '황두현', '황두현', 'doo@naver.com', '1997-04-26', '01023446673');
 
 INSERT into board_groups (id, name) VALUES (1, '백엔드'),


### PR DESCRIPTION
board와 관련된 기본적인 기능(게시판 그룹 조회, 게시판 조회, 즐겨찾기, 게시판 글 조회)을 추가하였습니다. 일단 postman 상으로는 문제가 없는 것 같은데 혹시 수정이 필요한 부분이 있다면 말씀해주세요. 구현하는 과정에서 엔티티나 다른 기능의 코드들을 일부 수정하였는데 다음과 같습니다.

-Article 엔티티에 comment와의 연관관계를 추가하였습니다. 코드는 슬렉에서 언급되었던 것과 같습니다. 게시판 글을 조회할 때 각 글의 댓글수가 필요한데, 현재는 comment 리스트를 받고 그 size를 구하는 식으로 구현하였습니다. Article 엔티티에 commentCnt 같은 변수가 있어도 좋을 것 같습니다.
-게시판 글 조회를 위해 ArticleRepository에 findByBoardId가 추가되었습니다.
-ArticleBrief라는 data class를 추가하였습니다.
-board와 boardLike 엔티티 사이 연관관계를 추가하였으며 엔티티의 list를 모두 mutablelist로 변경하였습니다.