### PR TITLE
board likeCnt 추가

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -18,13 +18,11 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long>{
     )
     fun incrementViewCnt(articleId: Long)
 
-    @Query("SELECT a FROM articles a JOIN FETCH a.user JOIN FETCH a.comments WHERE a.board.id = :boardId")
+    @Query("SELECT a FROM articles a JOIN FETCH a.user WHERE a.board.id = :boardId")
     fun findByBoardId(boardId: Long): List<ArticleEntity>
 
     fun findAllByOrderByViewCntDesc(): List<ArticleEntity>
     fun findAllByOrderByLikeCntDesc(): List<ArticleEntity>
     fun findAllByOrderByCommentCntDesc(): List<ArticleEntity>
-
-
 
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardEntity.kt
@@ -12,8 +12,8 @@ class BoardEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     val group: BoardGroupEntity,
-    val viewCnt: Long,
-    val likeCnt: Long,
+    var viewCnt: Long,
+    var likeCnt: Long,
     @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL])
     val articles: MutableList<ArticleEntity>,
     @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL])

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
@@ -1,7 +1,28 @@
 package com.example.cafe.board.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
 interface BoardLikeRepository : JpaRepository<BoardLikeEntity, Long> {
     fun findByUserIdAndBoardId(userId: Long, boardId: Long): BoardLikeEntity?
+
+    @Modifying
+    @Transactional
+    @Query(
+        """
+        UPDATE boards b SET b.likeCnt = b.likeCnt + 1 WHERE b.id = :boardId
+    """
+    )
+    fun incrementLikeCnt(boardId: Long)
+
+    @Modifying
+    @Transactional
+    @Query(
+        """
+        UPDATE boards b SET b.likeCnt = b.likeCnt - 1 WHERE b.id = :boardId
+    """
+    )
+    fun decrementLikeCnt(boardId: Long)
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
@@ -6,6 +6,7 @@ import com.example.cafe.board.repository.BoardRepository
 import com.example.cafe.user.repository.UserRepository
 import com.example.cafe.user.service.UserNotFoundException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class BoardLikeServiceImpl (
@@ -29,6 +30,7 @@ class BoardLikeServiceImpl (
         }
     }
 
+    @Transactional
     override fun create(userId: Long, boardId: Long) {
         val user = userRepository.findById(userId).orElseThrow { UserNotFoundException() }
         if (boardRepository.findById(boardId).isEmpty) {
@@ -45,14 +47,19 @@ class BoardLikeServiceImpl (
                 board = boardRepository.findById(boardId).get()
             )
         )
+
+        boardLikeRepository.incrementLikeCnt(boardId)
     }
 
+    @Transactional
     override fun delete(userId: Long, boardId: Long) {
         val user = userRepository.findById(userId).orElseThrow { UserNotFoundException() }
         val boardLike = boardLikeRepository.findByUserIdAndBoardId(user.id, boardId)
             ?: throw BoardNeverLikedException()
 
         boardLikeRepository.delete(boardLike)
+
+        boardLikeRepository.decrementLikeCnt(boardId)
     }
 
 }

--- a/cafe/src/test/kotlin/com/example/cafe/board/BoardLikeServiceTest.kt
+++ b/cafe/src/test/kotlin/com/example/cafe/board/BoardLikeServiceTest.kt
@@ -1,0 +1,53 @@
+package com.example.cafe.board
+
+import com.example.cafe.board.repository.BoardRepository
+import com.example.cafe.board.service.BoardLikeService
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BoardLikeServiceTest @Autowired constructor(
+    private val boardLikeService: BoardLikeService,
+    private val boardRepository: BoardRepository
+) {
+    @BeforeEach
+    fun init() {
+        boardLikeService.create(1, 1)
+        boardLikeService.create(1, 2)
+        boardLikeService.create(2, 1)
+    }
+
+    @Test
+    fun `likeCnt 증가`() {
+        val board1 = boardRepository.findById(1).get()
+        val board2 = boardRepository.findById(2).get()
+        val board3 = boardRepository.findById(3).get()
+
+        assertThat(board1.likeCnt).isEqualTo(2)
+        assertThat(board2.likeCnt).isEqualTo(1)
+        assertThat(board3.likeCnt).isEqualTo(0)
+
+        boardLikeService.delete(1, 1)
+        boardLikeService.delete(1, 2)
+        boardLikeService.delete(2, 1)
+    }
+
+    @Test
+    fun `likeCnt 감소`() {
+        boardLikeService.delete(1, 1)
+        boardLikeService.delete(1, 2)
+
+        val board1 = boardRepository.findById(1).get()
+        val board2 = boardRepository.findById(2).get()
+        val board3 = boardRepository.findById(3).get()
+
+        assertThat(board1.likeCnt).isEqualTo(1)
+        assertThat(board2.likeCnt).isEqualTo(0)
+        assertThat(board3.likeCnt).isEqualTo(0)
+        boardLikeService.delete(2, 1)
+    }
+
+}


### PR DESCRIPTION
board like, like 취소에 따른 likeCnt 개수 변화를 구현하였습니다. 다만 현재로써는 likeCnt가 딱히 중요하지는 않고 만약 추가구현으로 인기있는 게시판 같은 것을 만든다면 그때 쓰일 것 같습니다. 그 외에 article에 commentCnt가 추가되면서 findByBoardId의 query가 약간 수정되었습니다.