### PR TITLE
board pagination 구현

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -18,13 +18,11 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long>{
     )
     fun incrementViewCnt(articleId: Long)
 
-    @Query("SELECT a FROM articles a JOIN FETCH a.user JOIN FETCH a.comments WHERE a.board.id = :boardId")
+    @Query("SELECT a FROM articles a JOIN FETCH a.user WHERE a.board.id = :boardId")
     fun findByBoardId(boardId: Long): List<ArticleEntity>
 
     fun findAllByOrderByViewCntDesc(): List<ArticleEntity>
     fun findAllByOrderByLikeCntDesc(): List<ArticleEntity>
     fun findAllByOrderByCommentCntDesc(): List<ArticleEntity>
-
-
 
 }

--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -1,5 +1,7 @@
 package com.example.cafe.article.repository
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Page
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -19,7 +21,10 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long>{
     fun incrementViewCnt(articleId: Long)
 
     @Query("SELECT a FROM articles a JOIN FETCH a.user WHERE a.board.id = :boardId")
-    fun findByBoardId(boardId: Long): List<ArticleEntity>
+    fun findByBoardId(boardId: Long, pageable: Pageable): Page<ArticleEntity>
+
+    @Query("SELECT a FROM articles a JOIN FETCH a.user WHERE a.board.id = :boardId AND a.isNotification = true")
+    fun findByBoardIdAndNotification(boardId: Long): List<ArticleEntity>
 
     fun findAllByOrderByViewCntDesc(): List<ArticleEntity>
     fun findAllByOrderByLikeCntDesc(): List<ArticleEntity>

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -4,8 +4,11 @@ import com.example.cafe.article.service.ArticleBrief
 import com.example.cafe.board.service.*
 import com.example.cafe.user.service.Authenticated
 import com.example.cafe.user.service.User
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Page
 
 @RestController
 class BoardController(
@@ -50,8 +53,17 @@ class BoardController(
     @GetMapping("/api/v1/boards/{boardId}/articles")
     fun getBoardArticle(
         @PathVariable boardId: Long,
+        @RequestParam("size", defaultValue = "10") size: Int,
+        @RequestParam("page", defaultValue = "1") page: Int,
+    ):ArticleBriefPageResponse {
+        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page-1, size)))
+    }
+
+    @GetMapping("/api/v1/boards/{boardId}/notification")
+    fun getBoardNotification(
+        @PathVariable boardId: Long,
     ):ArticleBriefResponse {
-        return ArticleBriefResponse(boardService.getArticles(boardId))
+        return ArticleBriefResponse(boardService.getNotification(boardId))
     }
 
     @ExceptionHandler
@@ -76,4 +88,8 @@ data class BoardResponse(
 
 data class ArticleBriefResponse(
     val articleBrief: List<ArticleBrief>
+)
+
+data class ArticleBriefPageResponse(
+    val articleBrief: Page<ArticleBrief>
 )

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -57,13 +57,21 @@ class BoardController(
         @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("sort", defaultValue = "createdAt,desc") sort: List<String>,
     ):ArticleBriefPageResponse {
-        var direction = Sort.Direction.DESC
+        var desc = true
         if (sort.size > 1) {
-            if (sort[1] == "asc") direction = Sort.Direction.ASC
+            if (sort[1] == "asc") desc = false;
+        }
+        val property = sort[0]
+
+        val sortBy = when (desc) {
+            true -> Sort.by(Sort.Direction.DESC, property, "id")
+            false -> Sort.by(
+                Sort.Order.asc(property),
+                Sort.Order.desc("id")
+            )
         }
 
-        val property = sort[0]
-        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page, size, Sort.by(direction, property, "id"))))
+        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page, size, sortBy)))
     }
 
     @GetMapping("/api/v1/boards/{boardId}/notification")

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.Sort
 
 @RestController
 class BoardController(
@@ -55,8 +56,15 @@ class BoardController(
         @PathVariable boardId: Long,
         @RequestParam("size", defaultValue = "10") size: Int,
         @RequestParam("page", defaultValue = "1") page: Int,
+        @RequestParam("sort", defaultValue = "createdAt,desc") sort: List<String>,
     ):ArticleBriefPageResponse {
-        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page-1, size)))
+        var direction = Sort.Direction.DESC
+        if (sort.size > 1) {
+            if (sort[1] == "asc") direction = Sort.Direction.ASC
+        }
+
+        val property = sort[0]
+        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page-1, size, Sort.by(direction, property))))
     }
 
     @GetMapping("/api/v1/boards/{boardId}/notification")

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -59,7 +59,7 @@ class BoardController(
     ):ArticleBriefPageResponse {
         var desc = true
         if (sort.size > 1) {
-            if (sort[1] == "asc") desc = false;
+            if (sort[1] == "asc") desc = false
         }
         val property = sort[0]
 

--- a/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/controller/BoardController.kt
@@ -7,7 +7,6 @@ import com.example.cafe.user.service.User
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Sort
 
@@ -54,8 +53,8 @@ class BoardController(
     @GetMapping("/api/v1/boards/{boardId}/articles")
     fun getBoardArticle(
         @PathVariable boardId: Long,
-        @RequestParam("size", defaultValue = "10") size: Int,
-        @RequestParam("page", defaultValue = "1") page: Int,
+        @RequestParam("size", defaultValue = "15") size: Int,
+        @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("sort", defaultValue = "createdAt,desc") sort: List<String>,
     ):ArticleBriefPageResponse {
         var direction = Sort.Direction.DESC
@@ -64,7 +63,7 @@ class BoardController(
         }
 
         val property = sort[0]
-        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page-1, size, Sort.by(direction, property))))
+        return ArticleBriefPageResponse(boardService.getArticles(boardId, PageRequest.of(page, size, Sort.by(direction, property, "id"))))
     }
 
     @GetMapping("/api/v1/boards/{boardId}/notification")

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardEntity.kt
@@ -12,8 +12,8 @@ class BoardEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     val group: BoardGroupEntity,
-    val viewCnt: Long,
-    val likeCnt: Long,
+    var viewCnt: Long,
+    var likeCnt: Long,
     @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL])
     val articles: MutableList<ArticleEntity>,
     @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL])

--- a/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/repository/BoardLikeRepository.kt
@@ -1,7 +1,28 @@
 package com.example.cafe.board.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
 interface BoardLikeRepository : JpaRepository<BoardLikeEntity, Long> {
     fun findByUserIdAndBoardId(userId: Long, boardId: Long): BoardLikeEntity?
+
+    @Modifying
+    @Transactional
+    @Query(
+        """
+        UPDATE boards b SET b.likeCnt = b.likeCnt + 1 WHERE b.id = :boardId
+    """
+    )
+    fun incrementLikeCnt(boardId: Long)
+
+    @Modifying
+    @Transactional
+    @Query(
+        """
+        UPDATE boards b SET b.likeCnt = b.likeCnt - 1 WHERE b.id = :boardId
+    """
+    )
+    fun decrementLikeCnt(boardId: Long)
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardLikeServiceImpl.kt
@@ -6,6 +6,7 @@ import com.example.cafe.board.repository.BoardRepository
 import com.example.cafe.user.repository.UserRepository
 import com.example.cafe.user.service.UserNotFoundException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class BoardLikeServiceImpl (
@@ -29,6 +30,7 @@ class BoardLikeServiceImpl (
         }
     }
 
+    @Transactional
     override fun create(userId: Long, boardId: Long) {
         val user = userRepository.findById(userId).orElseThrow { UserNotFoundException() }
         if (boardRepository.findById(boardId).isEmpty) {
@@ -45,14 +47,19 @@ class BoardLikeServiceImpl (
                 board = boardRepository.findById(boardId).get()
             )
         )
+
+        boardLikeRepository.incrementLikeCnt(boardId)
     }
 
+    @Transactional
     override fun delete(userId: Long, boardId: Long) {
         val user = userRepository.findById(userId).orElseThrow { UserNotFoundException() }
         val boardLike = boardLikeRepository.findByUserIdAndBoardId(user.id, boardId)
             ?: throw BoardNeverLikedException()
 
         boardLikeRepository.delete(boardLike)
+
+        boardLikeRepository.decrementLikeCnt(boardId)
     }
 
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardService.kt
@@ -1,11 +1,15 @@
 package com.example.cafe.board.service
 
 import com.example.cafe.article.service.ArticleBrief
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface BoardService {
     fun get(): List<Board>
 
     fun getGroup(): List<BoardGroup>
 
-    fun getArticles(boardId: Long): List<ArticleBrief>
+    fun getArticles(boardId: Long, pageable: Pageable): Page<ArticleBrief>
+
+    fun getNotification(boardId: Long): List<ArticleBrief>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/board/service/BoardServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/board/service/BoardServiceImpl.kt
@@ -6,6 +6,8 @@ import com.example.cafe.board.repository.BoardGroupRepository
 import com.example.cafe.board.repository.BoardRepository
 import com.example.cafe.user.repository.UserEntity
 import com.example.cafe.user.service.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
 @Service
@@ -39,9 +41,28 @@ class BoardServiceImpl (
         }
     }
 
-    override fun getArticles(boardId: Long): List<ArticleBrief> {
+    override fun getArticles(boardId: Long, pageable: Pageable): Page<ArticleBrief> {
         val board = boardRepository.findById(boardId).orElseThrow{ BoardNotFoundException() }
-        val articleList = articleRepository.findByBoardId(boardId)
+        val articleList = articleRepository.findByBoardId(boardId, pageable)
+
+        return articleList.map {article->
+            ArticleBrief(
+                id = article.id,
+                title = article.title,
+                createdAt = article.createdAt,
+                viewCount = article.viewCnt,
+                likeCount = article.likeCnt,
+                commentCount = article.commentCnt,
+                author = User(article.user),
+                board = Board(id = board.id, name = board.name),
+                isNotification = article.isNotification,
+            )
+        }
+    }
+
+    override fun getNotification(boardId: Long): List<ArticleBrief> {
+        val board = boardRepository.findById(boardId).orElseThrow{ BoardNotFoundException() }
+        val articleList = articleRepository.findByBoardIdAndNotification(boardId)
 
         return articleList.map {article->
             ArticleBrief(

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -14,7 +14,21 @@ INSERT into boards (id, name, group_id) VALUES (1, '스프링', 1),
 (7, '자바스크립트', 3),
 (8, '리덕스', 2);
 
-INSERT into articles (id, title, content, created_at, user_id, board_id, allow_comments, is_notification) VALUES (1, '스프링이란', '스프링은 ..', CURRENT_TIMESTAMP, 1, 1, true, true);
+INSERT into articles (id, title, content, created_at, user_id, board_id, allow_comments, is_notification) VALUES (1, '스프링이란', '스프링은 ..', CURRENT_TIMESTAMP, 1, 1, true, true),
+(2, 'test2', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(3, 'test3', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(4, 'test4', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(5, 'test5', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(6, 'test6', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(7, 'test7', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(8, 'test8', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(9, 'test9', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(10, 'test10', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(11, 'test11', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(12, 'test12', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(13, 'test13', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(14, 'test14', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
+(15, 'test15', '.', CURRENT_TIMESTAMP, 1, 1, true, false);
 
 INSERT into comments (id, content, last_modified, user_id, article_id) VALUES (1, '잘 읽었습니다.', CURRENT_TIMESTAMP, 2, 1);
 

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -1,5 +1,5 @@
-INSERT into users (id, username, password, name, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', '홍길동', 'hong@naver.com', '2000-05-03', '01023453444'),
-(2, 'doo', 'doo123', '황두현', '황두현', 'doo@naver.com', '1997-04-26', '01023446673');
+INSERT into users (id, username, password, name, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', 'hong', 'hong@naver.com', '2000-05-03', '01023453444'),
+(2, 'doo', 'doo123', '황두현', 'doo', 'doo@naver.com', '1997-04-26', '01023446673');
 
 INSERT into board_groups (id, name) VALUES (1, '백엔드'),
 (2, '프론트엔드'),
@@ -14,21 +14,21 @@ INSERT into boards (id, name, group_id) VALUES (1, '스프링', 1),
 (7, '자바스크립트', 3),
 (8, '리덕스', 2);
 
-INSERT into articles (id, title, content, created_at, user_id, board_id, allow_comments, is_notification) VALUES (1, '스프링이란', '스프링은 ..', CURRENT_TIMESTAMP, 1, 1, true, true),
-(2, 'test2', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(3, 'test3', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(4, 'test4', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(5, 'test5', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(6, 'test6', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(7, 'test7', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(8, 'test8', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(9, 'test9', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(10, 'test10', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(11, 'test11', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(12, 'test12', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(13, 'test13', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(14, 'test14', '.', CURRENT_TIMESTAMP, 1, 1, true, false),
-(15, 'test15', '.', CURRENT_TIMESTAMP, 1, 1, true, false);
+INSERT into articles (id, title, content, created_at, user_id, board_id, allow_comments, is_notification) VALUES (1, '스프링이란', '스프링은 ..', '2023-01-01', 1, 1, true, true),
+(2, 'test2', '.', '2023-01-02', 1, 1, true, false),
+(3, 'test3', '.', '2023-01-03', 1, 1, true, false),
+(4, 'test4', '.', '2023-01-04', 1, 1, true, false),
+(5, 'test5', '.', '2023-01-05', 1, 1, true, false),
+(6, 'test6', '.', '2023-01-06', 1, 1, true, false),
+(7, 'test7', '.', '2023-01-07', 1, 1, true, false),
+(8, 'test8', '.', '2023-01-08', 1, 1, true, false),
+(9, 'test9', '.', '2023-01-09', 1, 1, true, false),
+(10, 'test10', '.', '2023-01-10', 1, 1, true, false),
+(11, 'test11', '.', '2023-01-11', 1, 1, true, false),
+(12, 'test12', '.', '2023-01-12', 1, 1, true, false),
+(13, 'test13', '.', '2023-01-13', 1, 1, true, false),
+(14, 'test14', '.', '2023-01-14', 1, 1, true, false),
+(15, 'test15', '.', '2023-01-15', 1, 1, true, false);
 
 INSERT into comments (id, content, last_modified, user_id, article_id) VALUES (1, '잘 읽었습니다.', CURRENT_TIMESTAMP, 2, 1);
 

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -27,8 +27,9 @@ INSERT into articles (id, title, content, created_at, user_id, board_id, allow_c
 (11, 'test11', '.', '2023-01-11', 1, 1, true, false),
 (12, 'test12', '.', '2023-01-12', 1, 1, true, false),
 (13, 'test13', '.', '2023-01-13', 1, 1, true, false),
-(14, 'test14', '.', '2023-01-14', 1, 1, true, false),
-(15, 'test15', '.', '2023-01-15', 1, 1, true, false);
+(16, 'test16', '.', '2023-01-14', 1, 1, true, false),
+(15, 'test15', '.', '2023-01-14', 1, 1, true, false),
+(14, 'test14', '.', '2023-01-14', 1, 1, true, false);
 
 INSERT into comments (id, content, last_modified, user_id, article_id) VALUES (1, '잘 읽었습니다.', CURRENT_TIMESTAMP, 2, 1);
 

--- a/cafe/src/test/kotlin/com/example/cafe/board/BoardLikeServiceTest.kt
+++ b/cafe/src/test/kotlin/com/example/cafe/board/BoardLikeServiceTest.kt
@@ -1,0 +1,53 @@
+package com.example.cafe.board
+
+import com.example.cafe.board.repository.BoardRepository
+import com.example.cafe.board.service.BoardLikeService
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BoardLikeServiceTest @Autowired constructor(
+    private val boardLikeService: BoardLikeService,
+    private val boardRepository: BoardRepository
+) {
+    @BeforeEach
+    fun init() {
+        boardLikeService.create(1, 1)
+        boardLikeService.create(1, 2)
+        boardLikeService.create(2, 1)
+    }
+
+    @Test
+    fun `likeCnt 증가`() {
+        val board1 = boardRepository.findById(1).get()
+        val board2 = boardRepository.findById(2).get()
+        val board3 = boardRepository.findById(3).get()
+
+        assertThat(board1.likeCnt).isEqualTo(2)
+        assertThat(board2.likeCnt).isEqualTo(1)
+        assertThat(board3.likeCnt).isEqualTo(0)
+
+        boardLikeService.delete(1, 1)
+        boardLikeService.delete(1, 2)
+        boardLikeService.delete(2, 1)
+    }
+
+    @Test
+    fun `likeCnt 감소`() {
+        boardLikeService.delete(1, 1)
+        boardLikeService.delete(1, 2)
+
+        val board1 = boardRepository.findById(1).get()
+        val board2 = boardRepository.findById(2).get()
+        val board3 = boardRepository.findById(3).get()
+
+        assertThat(board1.likeCnt).isEqualTo(1)
+        assertThat(board2.likeCnt).isEqualTo(0)
+        assertThat(board3.likeCnt).isEqualTo(0)
+        boardLikeService.delete(2, 1)
+    }
+
+}


### PR DESCRIPTION
게시판 게시글 조회에 페이지네이션 기능을 추가하였습니다. 이 부분은 세미나때 해보지 않았던 부분이라 부족한 점이 많을 수 있습니다. 수정이 필요하거나 더 좋은 방식이 있는 것 같으면 말씀해주세요.

-파라미터로 page, size, sort를 받아서 해당 페이지 게시글 리스트를 반환합니다. 각 파라미터가 하는 역할은 다음과 같습니다.
1. size(int): 한 페이지당 개시물 개수
2. page(int): 조회할 페이지 넘버. 0부터 시작
3. sort(string): {property},{direction} 형식 (ex. createdAt,desc / createdAt,asc / title,asc / likeCnt,desc …) property 값이 같을 경우 그 다음은 id 내림차순으로 정렬

-원래 네이버 카페에 한 페이지당 표시할 개시물 개수 설정은 있는데 정렬 설정은 없는 것 같네요. 그냥 default로 나둬도 되고 아니면 추가 기능으로 넣어도 될 것 같습니다. likeCnt, viewCnt로 정렬은 아직 테스트를 못해봐서 필요하면 merge 후 해봐야 할 것 같습니다.

-각 게시판 별 공지글만 모아볼 수 있는 api를 추가하였습니다. 이걸 만들었던 이유는 지금 전체 게시물을 한번에 가져오는 게 아니기 때문에 공지가 첫 페이지가 아닌 다른 페이지에 있다면 문제가 생길 수도 있을 거라고 생각해서였습니다. 다만 카페를 다시 보다보니 공지에도 전체 공지/게시판 공지/필동 공지로 나뉘던데, 저희는 이걸 bool 하나로 표현했기 때문에 전체 공지로 생각하는 편이 더 좋을 것 같네요. 일단 남겨두긴 했는데 전체 게시물 리스트를 article 쪽에서 만든 것으로 알고 있어서 그쪽으로 옮기는 게 좀 더 일관성있을 것 같습니다.

-테스트를 위해 data.sql이 수정되었습니다.