### PR TITLE
비밀 댓글, 대댓글 기능 구현

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
@@ -20,7 +20,7 @@ class CommentController(
     ) : PostCommentResponse {
         val comment = commentService.createComment(user.id, articleId, content, isSecret)
         return PostCommentResponse(
-            commentId = comment.id,
+            id = comment.id,
             content = comment.content,
             lastModified = comment.lastModified,
             nickname = comment.nickname,
@@ -70,7 +70,7 @@ class CommentController(
         ) : PostRecommentResponse {
         val recomment = commentService.createRecomment(user.id, commentId, content, isSecret)
         return PostRecommentResponse(
-            recommentId = recomment.id,
+            id = recomment.id,
             content = recomment.content,
             lastModified = recomment.lastModified,
             nickname = recomment.nickname,
@@ -125,7 +125,7 @@ class CommentController(
 }
 
 data class PostCommentResponse(
-    val commentId: Long,
+    val id: Long,
     val content: String,
     val lastModified: LocalDateTime,
     val nickname: String,
@@ -140,7 +140,7 @@ data class UpdateCommentResponse(
 )
 
 data class PostRecommentResponse(
-    val recommentId: Long,
+    val id: Long,
     val content: String,
     val lastModified: LocalDateTime,
     val nickname: String,

--- a/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
@@ -14,10 +14,11 @@ class CommentController(
     @PostMapping("/api/v1/articles/{articleId}/comments")
     fun postComment(
         @RequestParam content: String,
+        @RequestParam isSecret: Boolean,
         @PathVariable articleId: Long,
-        @Authenticated user: User
+        @Authenticated user: User,
     ) : PostCommentResponse {
-        val comment = commentService.createComment(user.id, articleId, content)
+        val comment = commentService.createComment(user.id, articleId, content, isSecret)
         return PostCommentResponse(
             commentId = comment.id,
             content = comment.content,
@@ -27,10 +28,15 @@ class CommentController(
     }
 
     @GetMapping("/api/v1/articles/{articleId}/comments")
-    fun getComment(
+    fun getComments(
         @PathVariable articleId: Long,
+        @Authenticated user: User?,
     ) : GetCommentResponse {
-        val comments = commentService.getComments(articleId)
+        val comments = if (user == null) {
+            commentService.getComments(-1, articleId) // 로그인하지 않은 경우
+        } else {
+            commentService.getComments(user.id, articleId) // 로그인한 경우
+        }
         return GetCommentResponse(comments = comments)
     }
 
@@ -57,11 +63,12 @@ class CommentController(
     @PostMapping("/api/v1/articles/{articleId}/comments/{commentId}/recomments")
     fun postRecomment(
         @RequestParam content: String,
+        @RequestParam isSecret: Boolean,
         @PathVariable articleId: Long,
         @PathVariable commentId: Long,
         @Authenticated user: User
         ) : PostRecommentResponse {
-        val recomment = commentService.createRecomment(user.id, commentId, content)
+        val recomment = commentService.createRecomment(user.id, commentId, content, isSecret)
         return PostRecommentResponse(
             recommentId = recomment.id,
             content = recomment.content,
@@ -71,11 +78,16 @@ class CommentController(
     }
 
     @GetMapping("/api/v1/articles/{articleId}/comments/{commentId}/recomments")
-    fun getRecomment(
+    fun getRecomments(
         @PathVariable articleId: Long,
         @PathVariable commentId: Long,
+        @Authenticated user: User?,
         ) : GetRecommentResponse {
-        val recomments = commentService.getRecomments(commentId)
+        val recomments = if (user == null) {
+            commentService.getRecomments(-1, commentId) // 로그인하지 않은 경우
+        } else {
+            commentService.getRecomments(user.id, commentId) // 로그인한 경우
+        }
         return GetRecommentResponse(recomments = recomments)
     }
 

--- a/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
@@ -24,6 +24,7 @@ class CommentController(
             content = comment.content,
             lastModified = comment.lastModified,
             nickname = comment.nickname,
+            isSecret = comment.isSecret,
         )
     }
 
@@ -74,6 +75,7 @@ class CommentController(
             content = recomment.content,
             lastModified = recomment.lastModified,
             nickname = recomment.nickname,
+            isSecret = recomment.isSecret,
         )
     }
 
@@ -129,6 +131,7 @@ data class PostCommentResponse(
     val content: String,
     val lastModified: LocalDateTime,
     val nickname: String,
+    val isSecret: Boolean,
 )
 
 data class GetCommentResponse(
@@ -144,6 +147,7 @@ data class PostRecommentResponse(
     val content: String,
     val lastModified: LocalDateTime,
     val nickname: String,
+    val isSecret: Boolean,
 )
 
 data class GetRecommentResponse(

--- a/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/controller/CommentController.kt
@@ -30,7 +30,7 @@ class CommentController(
     @GetMapping("/api/v1/articles/{articleId}/comments")
     fun getComments(
         @PathVariable articleId: Long,
-        @Authenticated user: User?,
+        user: User?,
     ) : GetCommentResponse {
         val comments = if (user == null) {
             commentService.getComments(-1, articleId) // 로그인하지 않은 경우
@@ -81,7 +81,7 @@ class CommentController(
     fun getRecomments(
         @PathVariable articleId: Long,
         @PathVariable commentId: Long,
-        @Authenticated user: User?,
+        user: User?,
         ) : GetRecommentResponse {
         val recomments = if (user == null) {
             commentService.getRecomments(-1, commentId) // 로그인하지 않은 경우

--- a/cafe/src/main/kotlin/com/example/cafe/comment/repository/CommentEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/repository/CommentEntity.kt
@@ -20,4 +20,5 @@ class CommentEntity(
     val article: ArticleEntity,
     @OneToMany(mappedBy = "comment", cascade = [CascadeType.REMOVE])
     val recomments: MutableList<RecommentEntity> = mutableListOf(),
+    val isSecret: Boolean = false,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/repository/RecommentEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/repository/RecommentEntity.kt
@@ -23,4 +23,5 @@ class RecommentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     val comment: CommentEntity,
+    val isSecret: Boolean = false,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/Comment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/Comment.kt
@@ -8,4 +8,5 @@ data class Comment(
     var lastModified: LocalDateTime,
     val nickname: String,
     val recomments: List<Recomment> = emptyList(),
+    val isSecret: Boolean,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentService.kt
@@ -3,10 +3,10 @@ package com.example.cafe.comment.service
 import java.time.LocalDateTime
 
 interface CommentService {
-    fun getComments(articleId: Long): List<Comment>
-    fun getRecomments(commentId: Long): List<Recomment>
-    fun createComment(userId: Long, articleId: Long, content: String, at: LocalDateTime = LocalDateTime.now()): Comment
-    fun createRecomment(userId: Long, commentId: Long, content: String, at: LocalDateTime = LocalDateTime.now()): Recomment
+    fun getComments(userId: Long, articleId: Long): List<Comment>
+    fun getRecomments(userId: Long, commentId: Long): List<Recomment>
+    fun createComment(userId: Long, articleId: Long, content: String, isSecret: Boolean, at: LocalDateTime = LocalDateTime.now()): Comment
+    fun createRecomment(userId: Long, commentId: Long, content: String, isSecret: Boolean, at: LocalDateTime = LocalDateTime.now()): Recomment
     fun updateComment(id: Long, userId: Long, content: String, at: LocalDateTime = LocalDateTime.now()) : Comment
     fun updateRecomment(id: Long, userId: Long, content: String, at: LocalDateTime = LocalDateTime.now()) : Recomment
     fun deleteComment(id: Long, userId: Long, articleId: Long)

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
@@ -52,8 +52,10 @@ class CommentServiceImpl (
                         },
                         lastModified = recommentEntity.lastModified,
                         nickname = recommentEntity.user.nickname,
+                        isSecret = recommentEntity.isSecret,
                     )
-                }
+                },
+                isSecret = commentEntity.isSecret,
             )
         }
         return comments
@@ -77,6 +79,7 @@ class CommentServiceImpl (
                 },
                 lastModified = recommentEntity.lastModified,
                 nickname = recommentEntity.user.nickname,
+                isSecret = recommentEntity.isSecret,
             )
         }
         return recomments
@@ -102,6 +105,7 @@ class CommentServiceImpl (
             content = comment.content,
             lastModified = comment.lastModified,
             nickname = comment.user.nickname,
+            isSecret = comment.isSecret,
         )
     }
 
@@ -122,6 +126,7 @@ class CommentServiceImpl (
             content = recomment.content,
             lastModified = recomment.lastModified,
             nickname = recomment.user.nickname,
+            isSecret = recomment.isSecret,
         )
     }
 
@@ -144,8 +149,10 @@ class CommentServiceImpl (
                     content = recommentEntity.content,
                     lastModified = recommentEntity.lastModified,
                     nickname = recommentEntity.user.nickname,
+                    isSecret = recommentEntity.isSecret,
                 )
-            }
+            },
+            isSecret = comment.isSecret,
         )
     }
 
@@ -162,6 +169,7 @@ class CommentServiceImpl (
             content = recomment.content,
             lastModified = recomment.lastModified,
             nickname = recomment.user.nickname,
+            isSecret = recomment.isSecret,
         )
     }
 

--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/Recomment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/Recomment.kt
@@ -7,4 +7,5 @@ data class Recomment(
     val content: String,
     var lastModified: LocalDateTime,
     val nickname: String,
+    val isSecret: Boolean,
 )

--- a/cafe/src/main/resources/schema.sql
+++ b/cafe/src/main/resources/schema.sql
@@ -89,6 +89,7 @@ create table comments (
     last_modified datetime not null,
     user_id bigint,
     article_id bigint,
+    is_secret boolean default false,
     primary key (id)
 );
 create table recomments (
@@ -97,5 +98,6 @@ create table recomments (
     last_modified datetime not null,
     user_id bigint,
     comment_id bigint,
+    is_secret boolean default false,
     primary key (id)
 );


### PR DESCRIPTION
비밀 댓글, 대댓글 기능 구현했습니다.
네이버 블로그에는 비밀 댓글 기능이 있는데 기존의 카페에는 없다고 해서 추가 기능으로 비밀 댓글 대댓글 기능 구현해봤습니다.
CommentEntity와 RecommentEntity에 isSecret: Boolean 을 추가하고 postComment와 postRecomment 에서 isSecret 을 RequestParam 으로 추가로 받도록 구현했습니다. (댓글 작성시 비밀 댓글인지만 추가로 받으면 될 것 같습니다)
comment를 비밀로 설정한 경우 comment 또는 article 작성자가 getComment 할 때만 content가 보이도록 하고 나머지 경우에는 "비밀 댓글입니다." 가 보이도록 했습니다.
recomment를 비밀로 설정한 경우 recomment 또는 comment 또는 article 작성자가 getRecomment 할 때만 content가 보이도록 하고 나머지 경우에는 "비밀 대댓글입니다." 가 보이도록 했습니다.
로그인 하지 않은 경우에도 비밀 댓글, 대댓글만 "비밀 댓글입니다.", "비밀 대댓글입니다." 로 보이도록 했습니다.
Postman으로 테스트해본 결과 잘 작동하는 것 같습니다.

추가로 Post에 대한 Response로 주던 commentId, recommentId를 id로 일관성 있게 수정했습니다.