### PR TITLE
내가 쓴 글 모아보기, 내가 좋아요한 글 모아보기 구현

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleEntity.kt
@@ -1,6 +1,7 @@
 package com.example.cafe.article.repository
 
 import com.example.cafe.board.repository.BoardEntity
+import com.example.cafe.board.repository.BoardLikeEntity
 import com.example.cafe.comment.repository.CommentEntity
 import com.example.cafe.user.repository.UserEntity
 import jakarta.persistence.*
@@ -28,4 +29,6 @@ class ArticleEntity (
         val isNotification : Boolean,
         @OneToMany(mappedBy = "article", cascade = [CascadeType.REMOVE])
         val comments: MutableList<CommentEntity> = mutableListOf(),
+        @OneToMany(mappedBy = "article", cascade = [CascadeType.ALL])
+        val articleLikes: MutableList<ArticleLikeEntity> = mutableListOf(),
 )

--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleLikeEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleLikeEntity.kt
@@ -1,15 +1,14 @@
 package com.example.cafe.article.repository
 
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
+import jakarta.persistence.*
 
 @Entity(name = "article_likes")
 class ArticleLikeEntity(
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         val id: Long = 0,
-        val articleId: Long,
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "article_id")
+        val article: ArticleEntity,
         val userId: Long,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -38,12 +38,14 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long>{
     )
     fun decrementLikeCnt(articleId: Long)
 
-
     @Query("SELECT a FROM articles a JOIN FETCH a.user WHERE a.board.id = :boardId")
     fun findByBoardId(boardId: Long, pageable: Pageable): Page<ArticleEntity>
 
     @Query("SELECT a FROM articles a JOIN FETCH a.user WHERE a.board.id = :boardId AND a.isNotification = true")
     fun findByBoardIdAndNotification(boardId: Long): List<ArticleEntity>
+
+    @Query("SELECT al.article FROM article_likes al WHERE al.userId = :userId")
+    fun findByArticleLikeUserId(userId: Long, pageable: Pageable): Page<ArticleEntity>
 
     fun findAllByOrderByViewCntDesc(): List<ArticleEntity>
     fun findAllByOrderByLikeCntDesc(): List<ArticleEntity>

--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -47,6 +47,9 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long>{
     @Query("SELECT al.article FROM article_likes al WHERE al.userId = :userId")
     fun findByArticleLikeUserId(userId: Long, pageable: Pageable): Page<ArticleEntity>
 
+    @Query("SELECT a FROM articles a JOIN a.user WHERE a.user.id = :userId")
+    fun findByUserId(userId: Long, pageable: Pageable): Page<ArticleEntity>
+
     fun findAllByOrderByViewCntDesc(): List<ArticleEntity>
     fun findAllByOrderByLikeCntDesc(): List<ArticleEntity>
     fun findAllByOrderByCommentCntDesc(): List<ArticleEntity>

--- a/cafe/src/main/kotlin/com/example/cafe/article/service/ArticleLikeServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/service/ArticleLikeServiceImpl.kt
@@ -15,7 +15,7 @@ class ArticleLikeServiceImpl(
     }
 
     override fun create(articleId: Long, userId: Long) {
-        articleRepository.findById(articleId).orElseThrow{ ArticleNotFoundException() }
+        val article = articleRepository.findById(articleId).orElseThrow{ ArticleNotFoundException() }
 
         if (exists(articleId = articleId, userId = userId)) {
             throw ArticleAlreadyLikedException()
@@ -23,7 +23,7 @@ class ArticleLikeServiceImpl(
 
         articleLikeRepository.save(
                 ArticleLikeEntity(
-                        articleId = articleId,
+                        article = article,
                         userId = userId
                 )
         )

--- a/cafe/src/main/kotlin/com/example/cafe/article/service/UserArticleBrief.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/service/UserArticleBrief.kt
@@ -1,0 +1,14 @@
+package com.example.cafe.article.service
+
+import com.example.cafe.user.service.User
+import java.time.LocalDateTime
+
+data class UserArticleBrief (
+    val id: Long,
+    val title: String,
+    val createdAt: LocalDateTime,
+    val viewCount: Long,
+    val likeCount: Long,
+    val commentCount: Long,
+    val author: User,
+)

--- a/cafe/src/main/kotlin/com/example/cafe/article/service/UserArticleBrief.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/service/UserArticleBrief.kt
@@ -8,7 +8,6 @@ data class UserArticleBrief (
     val title: String,
     val createdAt: LocalDateTime,
     val viewCount: Long,
-    val likeCount: Long,
     val commentCount: Long,
     val author: User,
 )

--- a/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
@@ -1,8 +1,12 @@
 package com.example.cafe.user.controller
 
 import com.example.cafe.user.service.*
+import com.example.cafe.article.service.UserArticleBrief
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Page
 
 @RestController
 class UserController(
@@ -50,6 +54,16 @@ class UserController(
         return UserBriefResponse(userBrief = userService.getUserBrief(user.id))
     }
 
+    @GetMapping("/api/v1/users/articles")
+    fun getLikeArticles(
+        @Authenticated user: User,
+        @RequestParam("size", defaultValue = "15") size: Int,
+        @RequestParam("page", defaultValue = "0") page: Int,
+        @RequestParam("sort", defaultValue = "id") sort: String,
+    ): UserArticleBriefPageResponse {
+        return UserArticleBriefPageResponse(userService.getLikeArticles(user.id, PageRequest.of(page, size, Sort.by(sort))))
+    }
+
     @ExceptionHandler
     fun handleException(e: UserException): ResponseEntity<Unit> {
         val status = when (e) {
@@ -85,4 +99,7 @@ data class UpdateProfileRequest(
 
 data class UserBriefResponse(
     val userBrief: UserBrief
+)
+data class UserArticleBriefPageResponse(
+    val articleBrief: Page<UserArticleBrief>
 )

--- a/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
@@ -54,14 +54,24 @@ class UserController(
         return UserBriefResponse(userBrief = userService.getUserBrief(user.id))
     }
 
-    @GetMapping("/api/v1/users/articles")
-    fun getLikeArticles(
+    @GetMapping("/api/v1/users/liked-articles")
+    fun getLikedArticles(
         @Authenticated user: User,
         @RequestParam("size", defaultValue = "15") size: Int,
         @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("sort", defaultValue = "id") sort: String,
     ): UserArticleBriefPageResponse {
         return UserArticleBriefPageResponse(userService.getLikeArticles(user.id, PageRequest.of(page, size, Sort.by(sort))))
+    }
+
+    @GetMapping("/api/v1/users/articles")
+    fun getMyArticles(
+        @Authenticated user: User,
+        @RequestParam("size", defaultValue = "15") size: Int,
+        @RequestParam("page", defaultValue = "0") page: Int,
+        @RequestParam("sort", defaultValue = "createdAt") sort: String,
+    ): UserArticleBriefPageResponse {
+        return UserArticleBriefPageResponse(userService.getMyArticles(user.id, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sort))))
     }
 
     @ExceptionHandler

--- a/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
@@ -62,12 +62,12 @@ class UserController(
         return UserArticleBriefPageResponse(userService.getLikeArticles(user.id, PageRequest.of(page, 15, Sort.by(Sort.Direction.DESC, "id"))))
     }
 
-    @GetMapping("/api/v1/users/articles")
-    fun getMyArticles(
-        @Authenticated user: User,
+    @GetMapping("/api/v1/users/articles/{nickname}")
+    fun getUserArticles(
+        @PathVariable nickname: String,
         @RequestParam("page", defaultValue = "0") page: Int,
     ): UserArticleBriefPageResponse {
-        return UserArticleBriefPageResponse(userService.getMyArticles(user.id, PageRequest.of(page, 15, Sort.by(Sort.Direction.DESC, "createdAt", "id"))))
+        return UserArticleBriefPageResponse(userService.getUserArticles(nickname, PageRequest.of(page, 15, Sort.by(Sort.Direction.DESC, "createdAt", "id"))))
     }
 
     @ExceptionHandler

--- a/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
@@ -57,21 +57,17 @@ class UserController(
     @GetMapping("/api/v1/users/liked-articles")
     fun getLikedArticles(
         @Authenticated user: User,
-        @RequestParam("size", defaultValue = "15") size: Int,
         @RequestParam("page", defaultValue = "0") page: Int,
-        @RequestParam("sort", defaultValue = "id") sort: String,
     ): UserArticleBriefPageResponse {
-        return UserArticleBriefPageResponse(userService.getLikeArticles(user.id, PageRequest.of(page, size, Sort.by(sort))))
+        return UserArticleBriefPageResponse(userService.getLikeArticles(user.id, PageRequest.of(page, 15, Sort.by(Sort.Direction.DESC, "id"))))
     }
 
     @GetMapping("/api/v1/users/articles")
     fun getMyArticles(
         @Authenticated user: User,
-        @RequestParam("size", defaultValue = "15") size: Int,
         @RequestParam("page", defaultValue = "0") page: Int,
-        @RequestParam("sort", defaultValue = "createdAt") sort: String,
     ): UserArticleBriefPageResponse {
-        return UserArticleBriefPageResponse(userService.getMyArticles(user.id, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sort))))
+        return UserArticleBriefPageResponse(userService.getMyArticles(user.id, PageRequest.of(page, 15, Sort.by(Sort.Direction.DESC, "createdAt", "id"))))
     }
 
     @ExceptionHandler
@@ -110,6 +106,7 @@ data class UpdateProfileRequest(
 data class UserBriefResponse(
     val userBrief: UserBrief
 )
+
 data class UserArticleBriefPageResponse(
     val articleBrief: Page<UserArticleBrief>
 )

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
@@ -1,6 +1,8 @@
 package com.example.cafe.user.service
 
-import com.example.cafe.user.repository.UserEntity
+import com.example.cafe.article.service.UserArticleBrief
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 interface UserService {
@@ -10,4 +12,5 @@ interface UserService {
     fun delete(id: Long)
     fun getUserBrief(id: Long): UserBrief
     fun authenticate(accessToken: String): User
+    fun getLikeArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
@@ -13,5 +13,5 @@ interface UserService {
     fun getUserBrief(id: Long): UserBrief
     fun authenticate(accessToken: String): User
     fun getLikeArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
-    fun getMyArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
+    fun getUserArticles(username: String, pageable: Pageable): Page<UserArticleBrief>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
@@ -13,4 +13,5 @@ interface UserService {
     fun getUserBrief(id: Long): UserBrief
     fun authenticate(accessToken: String): User
     fun getLikeArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
+    fun getMyArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -110,7 +110,6 @@ class UserServiceImpl (
                 title = article.title,
                 createdAt = article.createdAt,
                 viewCount = article.viewCnt,
-                likeCount = article.likeCnt,
                 commentCount = article.commentCnt,
                 author = User(user)
             )
@@ -127,7 +126,6 @@ class UserServiceImpl (
                 title = article.title,
                 createdAt = article.createdAt,
                 viewCount = article.viewCnt,
-                likeCount = article.likeCnt,
                 commentCount = article.commentCnt,
                 author = User(user)
             )

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -117,6 +117,23 @@ class UserServiceImpl (
         }
     }
 
+    override fun getMyArticles(id: Long, pageable: Pageable): Page<UserArticleBrief> {
+        val user = userRepository.findById(id).orElseThrow { UserNotFoundException() }
+        val articleList = articleRepository.findByUserId(id, pageable)
+
+        return articleList.map {article->
+            UserArticleBrief(
+                id = article.id,
+                title = article.title,
+                createdAt = article.createdAt,
+                viewCount = article.viewCnt,
+                likeCount = article.likeCnt,
+                commentCount = article.commentCnt,
+                author = User(user)
+            )
+        }
+    }
+
     private fun validate(username: String, password: String, email: String, birthDate: String, phoneNumber: String) {
         val validationUtil = ValidationUtil()
 

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -116,9 +116,9 @@ class UserServiceImpl (
         }
     }
 
-    override fun getMyArticles(id: Long, pageable: Pageable): Page<UserArticleBrief> {
-        val user = userRepository.findById(id).orElseThrow { UserNotFoundException() }
-        val articleList = articleRepository.findByUserId(id, pageable)
+    override fun getUserArticles(nickname: String, pageable: Pageable): Page<UserArticleBrief> {
+        val user = userRepository.findByNickname(nickname)?: throw UserNotFoundException()
+        val articleList = articleRepository.findByUserId(user.id, pageable)
 
         return articleList.map {article->
             UserArticleBrief(

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -1,12 +1,16 @@
 package com.example.cafe.user.service
 
 import com.example.cafe._web.exception.AuthenticateException
+import com.example.cafe.article.repository.ArticleRepository
+import com.example.cafe.article.service.UserArticleBrief
 import com.example.cafe.security.SecurityService
 import com.example.cafe.cafe.repository.CafeRepository
 import com.example.cafe.user.repository.UserEntity
 import com.example.cafe.user.repository.UserRepository
 import com.example.cafe.user.util.ValidationUtil
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.sql.Date
 import java.text.SimpleDateFormat
@@ -17,6 +21,7 @@ class UserServiceImpl (
     private val userRepository: UserRepository,
     private val securityService: SecurityService,
     private val cafeRepository: CafeRepository,
+    private val articleRepository: ArticleRepository
 ) : UserService {
     @Transactional
     override fun signUp(
@@ -93,6 +98,23 @@ class UserServiceImpl (
         val entity = userRepository.findById(id).orElseThrow { AuthenticateException() }
 
         return User(entity)
+    }
+
+    override fun getLikeArticles(id: Long, pageable: Pageable): Page<UserArticleBrief> {
+        val user = userRepository.findById(id).orElseThrow { UserNotFoundException() }
+        val articleList = articleRepository.findByArticleLikeUserId(id, pageable)
+
+        return articleList.map {article->
+            UserArticleBrief(
+                id = article.id,
+                title = article.title,
+                createdAt = article.createdAt,
+                viewCount = article.viewCnt,
+                likeCount = article.likeCnt,
+                commentCount = article.commentCnt,
+                author = User(user)
+            )
+        }
     }
 
     private fun validate(username: String, password: String, email: String, birthDate: String, phoneNumber: String) {

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -29,7 +29,10 @@ INSERT into articles (id, title, content, created_at, user_id, board_id, allow_c
 (13, 'test13', '.', '2023-01-13', 1, 1, true, false),
 (16, 'test16', '.', '2023-01-14', 1, 1, true, false),
 (15, 'test15', '.', '2023-01-14', 1, 1, true, false),
-(14, 'test14', '.', '2023-01-14', 1, 1, true, false);
+(14, 'test14', '.', '2023-01-14', 1, 1, true, false),
+(17, 'A', '.', '2023-01-14', 1, 2, true, false),
+(18, 'B', '.', '2023-01-14', 1, 2, true, false),
+(19, 'C', '.', '2023-01-14', 1, 2, true, false);
 
 INSERT into comments (id, content, last_modified, user_id, article_id) VALUES (1, '잘 읽었습니다.', CURRENT_TIMESTAMP, 2, 1);
 

--- a/cafe/src/main/resources/data.sql
+++ b/cafe/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT into users (id, username, password, name, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', 'hong', 'hong@naver.com', '2000-05-03', '01023453444'),
+INSERT into users (id, username, password, name, nickname, email, birth_date, phone_number) VALUES (1, 'hong', 'hong123', '홍길동', '홍길동', 'hong@naver.com', '2000-05-03', '01023453444'),
 (2, 'doo', 'doo123', '황두현', 'doo', 'doo@naver.com', '1997-04-26', '01023446673');
 
 INSERT into board_groups (id, name) VALUES (1, '백엔드'),
@@ -26,10 +26,10 @@ INSERT into articles (id, title, content, created_at, user_id, board_id, allow_c
 (10, 'test10', '.', '2023-01-10', 1, 1, true, false),
 (11, 'test11', '.', '2023-01-11', 1, 1, true, false),
 (12, 'test12', '.', '2023-01-12', 1, 1, true, false),
-(13, 'test13', '.', '2023-01-13', 1, 1, true, false),
-(16, 'test16', '.', '2023-01-14', 1, 1, true, false),
-(15, 'test15', '.', '2023-01-14', 1, 1, true, false),
-(14, 'test14', '.', '2023-01-14', 1, 1, true, false),
+(13, 'test13', '.', '2023-01-13', 2, 1, true, false),
+(16, 'test16', '.', '2023-01-14', 2, 1, true, false),
+(15, 'test15', '.', '2023-01-14', 2, 1, true, false),
+(14, 'test14', '.', '2023-01-14', 2, 1, true, false),
 (17, 'A', '.', '2023-01-14', 1, 2, true, false),
 (18, 'B', '.', '2023-01-14', 1, 2, true, false),
 (19, 'C', '.', '2023-01-14', 1, 2, true, false);


### PR DESCRIPTION
내가 쓴 글 모아보기, 내가 좋아요한 글 모아보기 기능을 구현하였습니다.

-articleEntity,  articleLikeEntity 사이의 연관관계가 추가되었습니다.

-data class UserArticleBrief가 추가되었습니다.

-슬랙에서 언급했던대로, size 설정 파라미터나 sort 설정 파라미터는 넣지 않았고 page만 받습니다. size는 15개로 고정되었고 기본 sort는 다음과 같습니다.

1. 내가 쓴 글: 최신순 정렬
2. 좋아요 한 글: 최근에 좋아요 한 순서. 다만 지금 ArticleLikeEntity에 생성시각이 들어있진 않아서 정확히는 ArticleLikeEntity id의 내림차순으로 정렬됩니다.