### PR TITLE
유저가 쓴 댓글 조회 + 유저가 댓글 단 글 조회 + 페이지네이션 구현

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/repository/ArticleRepository.kt
@@ -48,6 +48,9 @@ interface ArticleRepository : JpaRepository<ArticleEntity, Long>, CustomArticleR
     @Query("SELECT a FROM articles a JOIN a.user WHERE a.user.id = :userId")
     fun findByUserId(userId: Long, pageable: Pageable): Page<ArticleEntity>
 
+    @Query("SELECT distinct a FROM articles a JOIN a.comments ac WHERE ac.user.id = :userId")
+    fun findByCommentUserId(userId: Long, pageable: Pageable): Page<ArticleEntity>
+
     @Query("SELECT a FROM articles a JOIN FETCH a.user JOIN FETCH a.board WHERE a.isNotification = true")
     fun findByIsNotificationTrue(): List<ArticleEntity>
 

--- a/cafe/src/main/kotlin/com/example/cafe/article/service/CommentedArticle.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/article/service/CommentedArticle.kt
@@ -1,0 +1,12 @@
+package com.example.cafe.article.service
+
+import java.time.LocalDateTime
+
+data class CommentedArticle(
+    val id: Long,
+    val title: String,
+    val createdAt: LocalDateTime,
+    val viewCnt: Long,
+    val commentCnt: Long,
+    val authorNickname: String,
+)

--- a/cafe/src/main/kotlin/com/example/cafe/comment/repository/CommentRepository.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/repository/CommentRepository.kt
@@ -3,6 +3,8 @@ package com.example.cafe.comment.repository
 import com.example.cafe.article.service.ArticleBrief
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Page
 
 interface CommentRepository : JpaRepository<CommentEntity, Long> {
     fun findByContentContaining(item: String): List<CommentEntity>
@@ -12,4 +14,7 @@ interface CommentRepository : JpaRepository<CommentEntity, Long> {
         """
     )
     fun findByUser_NicknameContaining(item: String): List<CommentEntity>
+
+    @Query("SELECT c FROM comments c JOIN c.user WHERE c.user.id = :userId")
+    fun findAllByUserId(userId: Long, pageable: Pageable): Page<CommentEntity>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
@@ -1,5 +1,6 @@
 package com.example.cafe.user.controller
 
+import com.example.cafe.article.service.CommentedArticle
 import com.example.cafe.user.service.*
 import com.example.cafe.article.service.UserArticleBrief
 import org.springframework.data.domain.PageRequest
@@ -108,6 +109,19 @@ class UserController(
         )
     }
 
+    @GetMapping("/api/v1/users/{nickname}/commented-articles")
+    fun getUserCommentedArticles(
+        @PathVariable nickname: String,
+        @RequestParam("page", defaultValue = "1") page: Int,
+    ): CommentedArticlesPageResponse {
+        return CommentedArticlesPageResponse(
+            userService.getUserCommentedArticles(
+                nickname,
+                PageRequest.of(page-1, 15, Sort.by(Sort.Direction.DESC, "id", "createdAt"))
+            )
+        )
+    }
+
     @ExceptionHandler
     fun handleException(e: UserException): ResponseEntity<Unit> {
         val status = when (e) {
@@ -155,6 +169,10 @@ class UserController(
 
     data class  UserCommentsPageResponse(
         val userComments: Page<UserComment>
+    )
+
+    data class CommentedArticlesPageResponse(
+        val commentedArticles: Page<CommentedArticle>
     )
 }
 

--- a/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/controller/UserController.kt
@@ -95,6 +95,19 @@ class UserController(
         )
     }
 
+    @GetMapping("/api/v1/users/comments")
+    fun getUserComments(
+        @RequestParam("page", defaultValue = "1") page: Int,
+        @Authenticated user: User,
+    ): UserCommentsPageResponse {
+        return UserCommentsPageResponse(
+            userService.getUserComments(
+                user.id,
+                PageRequest.of(page - 1, 15, Sort.by(Sort.Direction.DESC, "lastModified", "id"))
+            )
+        )
+    }
+
     @ExceptionHandler
     fun handleException(e: UserException): ResponseEntity<Unit> {
         val status = when (e) {
@@ -138,6 +151,10 @@ class UserController(
 
     data class UserArticleBriefPageResponse(
         val articleBrief: Page<UserArticleBrief>
+    )
+
+    data class  UserCommentsPageResponse(
+        val userComments: Page<UserComment>
     )
 }
 

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserComment.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserComment.kt
@@ -1,0 +1,13 @@
+package com.example.cafe.user.service
+
+import java.time.LocalDateTime
+
+data class UserComment(
+    val id: Long,
+    val articleId: Long,
+    val content: String,
+    val nickname: String,
+    val lastModified: LocalDateTime,
+    val articleTitle: String,
+    val articleCommentCnt: Long,
+)

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
@@ -16,4 +16,5 @@ interface UserService {
     fun getUserInfo(nickname: String): UserInfo
     fun getLikeArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
     fun getUserArticles(username: String, pageable: Pageable): Page<UserArticleBrief>
+    fun getUserComments(userId: Long, pageable: Pageable): Page<UserComment>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.example.cafe.user.service
 
+import com.example.cafe.article.service.CommentedArticle
 import com.example.cafe.article.service.UserArticleBrief
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -17,4 +18,5 @@ interface UserService {
     fun getLikeArticles(id: Long, pageable: Pageable): Page<UserArticleBrief>
     fun getUserArticles(username: String, pageable: Pageable): Page<UserArticleBrief>
     fun getUserComments(userId: Long, pageable: Pageable): Page<UserComment>
+    fun getUserCommentedArticles(nickname: String, pageable: Pageable): Page<CommentedArticle>
 }

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -3,6 +3,7 @@ package com.example.cafe.user.service
 import com.example.cafe._web.exception.AuthenticateException
 import com.example.cafe.article.repository.ArticleRepository
 import com.example.cafe.article.service.ArticleBrief
+import com.example.cafe.article.service.CommentedArticle
 import com.example.cafe.board.service.Board
 import com.example.cafe.article.service.UserArticleBrief
 import com.example.cafe.security.SecurityService
@@ -189,6 +190,22 @@ class UserServiceImpl (
                 lastModified = commentEntity.lastModified,
                 articleTitle = commentEntity.article.title,
                 articleCommentCnt = commentEntity.article.commentCnt,
+            )
+        }
+    }
+
+    override fun getUserCommentedArticles(nickname: String, pageable: Pageable): Page<CommentedArticle> {
+        val user = userRepository.findByNickname(nickname)?: throw UserNotFoundException()
+        val articleList = articleRepository.findByCommentUserId(user.id, pageable)
+
+        return articleList.map { articleEntity ->
+            CommentedArticle(
+                id = articleEntity.id,
+                title = articleEntity.title,
+                createdAt = articleEntity.createdAt,
+                viewCnt = articleEntity.viewCnt,
+                commentCnt = articleEntity.commentCnt,
+                authorNickname = articleEntity.user.nickname,
             )
         }
     }

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -7,6 +7,7 @@ import com.example.cafe.board.service.Board
 import com.example.cafe.article.service.UserArticleBrief
 import com.example.cafe.security.SecurityService
 import com.example.cafe.cafe.repository.CafeRepository
+import com.example.cafe.comment.repository.CommentRepository
 import com.example.cafe.user.repository.UserEntity
 import com.example.cafe.user.repository.UserRepository
 import com.example.cafe.user.util.RandomNicknameGenerator
@@ -15,6 +16,7 @@ import jakarta.transaction.Transactional
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.sql.Date
 import java.text.SimpleDateFormat
@@ -26,6 +28,7 @@ class UserServiceImpl (
     private val articleRepository: ArticleRepository,
     private val securityService: SecurityService,
     private val cafeRepository: CafeRepository,
+    private val commentRepository: CommentRepository,
 ) : UserService {
     @Transactional
     override fun signUp(
@@ -169,6 +172,23 @@ class UserServiceImpl (
                 viewCount = article.viewCnt,
                 commentCount = article.commentCnt,
                 author = User(user)
+            )
+        }
+    }
+
+    override fun getUserComments(userId: Long, pageable: Pageable): Page<UserComment> {
+        val user = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
+        val commentList = commentRepository.findAllByUserId(userId, pageable)
+
+        return commentList.map { commentEntity ->
+            UserComment(
+                id = commentEntity.id,
+                articleId = commentEntity.article.id,
+                content = commentEntity.content,
+                nickname = user.nickname,
+                lastModified = commentEntity.lastModified,
+                articleTitle = commentEntity.article.title,
+                articleCommentCnt = commentEntity.article.commentCnt,
             )
         }
     }


### PR DESCRIPTION
Recomment는 고려하지 않고 comment만 고려하여 유저가 쓴 댓글 조회, 댓글 단 글 조회 + 페이지네이션 구현했습니다.
유저가 쓴 댓글은 수정(작성)한 시간 내림차순으로 정렬했고 댓글단 글은 article id 내림차순으로 정렬했습니다.
Postman으로 제가 해봤을 때는 문제 없었습니다. 그러나 많이 해본 것이 아니라서 더 확인해보겠습니다.
api 문서도 업데이트했습니다.