### PR TITLE
recomment는 commentCnt에 영향이 없도록 수정

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/comment/service/CommentServiceImpl.kt
@@ -129,8 +129,6 @@ class CommentServiceImpl (
                 isSecret = isSecret,
             )
         )
-        articleRepository.incrementCommentCnt(articleId)
-        userRepository.incrementCommentsCount(userId)
 
         return Recomment(
             id = recomment.id,
@@ -208,7 +206,5 @@ class CommentServiceImpl (
             throw UnauthorizedCommentUserException()
         }
         recommentRepository.delete(recomment)
-        articleRepository.decrementCommentCnt(articleId)
-        userRepository.decrementCommentsCount(userId)
     }
 }


### PR DESCRIPTION
기존에는 recomment를 생성하거나 삭제할 때 article이나 user의 commentCnt가 증가, 감소했습니다.
그러나 recomment는 댓글로 고려하지 않기로 했기 때문에 commentCnt에 영향이 없도록 수정했습니다.