### PR TITLE
article을 삭제할때 user의 commentCnt 업데이트

### DIFF
--- a/cafe/src/main/kotlin/com/example/cafe/user/repository/UserEntity.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/repository/UserEntity.kt
@@ -31,7 +31,7 @@ class UserEntity(
     var image: String? = null,
     val visitCount: Long = 0L,
     val articlesCount: Long = 0L,
-    val commentsCount: Long = 0L,
+    var commentsCount: Long = 0L,
     @OneToMany(mappedBy = "user")
     val articles: List<ArticleEntity> = mutableListOf(),
     @OneToMany(mappedBy = "user")

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -123,8 +123,11 @@ class UserServiceImpl (
         return UserProfile(nickname = entity.nickname, introduction = entity.introduction, image = entity.image)
     }
 
+    @Transactional
     override fun getUserInfo(nickname: String): UserInfo {
         val entity: UserEntity = userRepository.findByNickname(nickname)?: throw UserNotFoundException()
+        val commentCnt = entity.comments.size.toLong()
+        entity.commentsCount = commentCnt
 
         val pageable = PageRequest.of(0, 15)
         val articles = articleRepository.findFirst15ByUserId(userId = entity.id, pageable = pageable)

--- a/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
+++ b/cafe/src/main/kotlin/com/example/cafe/user/service/UserServiceImpl.kt
@@ -93,8 +93,11 @@ class UserServiceImpl (
         cafeRepository.decrementMemberCnt(1)
     }
 
+    @Transactional
     override fun getUserBrief(id: Long): UserBrief {
         val entity: UserEntity = userRepository.findById(id).orElseThrow { UserNotFoundException() }
+        val commentCnt = entity.comments.size.toLong()
+        entity.commentsCount = commentCnt
 
         return UserBrief(
             nickname = entity.nickname,


### PR DESCRIPTION
article을 삭제하면 자동으로 그 article의 comment가 사라집니다.
그러나 user의 commentCnt는 업데이트 되지 않아서 User 정보를 가져올 때 commentCnt를 업데이트해주도록 구현했습니다.